### PR TITLE
remove drop shaddows and fix form and button colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adhawk-theme",
-  "version": "2.0.5",
+  "version": "2.0.7",
   "description": "SCSS theme for AdHawk",
   "repository": "https://github.com/adhawk/adhawk-theme",
   "scripts": {

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -37,6 +37,7 @@
 .btn {
   @include transition(.25s background-color);
   position: relative;
+  box-shadow:none;
 
   &:not(.btn-link) {
     border: 1px solid transparent;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -60,10 +60,13 @@
   padding: 8px;
 }
 
-.btn-group > .active {
-  background: #37474F;
-  color: #ffffff;
-  font-weight: 700;
+.btn-toolbar,
+.btn-group {
+  .active {
+    background: #37474F;
+    color: #ffffff;
+    font-weight: 700;
+  }
 }
 
 .btn-group {
@@ -252,4 +255,12 @@ h4 {
 
 .form-control {
   height: 36px;
+  font-size: 18px;
+  font-weight: 600px;
+  box-shadow: none;
 }
+#focusedInput {
+  background-color: #ffffff;
+  border: solid 1px #263238;
+}
+


### PR DESCRIPTION
this removes box-shadows from form elements, makes the color of btn-toolbar active use the same styling as btn-group active and increases the size of the text in forms